### PR TITLE
Use Rust target for 32 or 64 bit

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,11 +4,11 @@ set -ex
 
 RUST_TARGET="x86_64-unknown-linux-gnu"
 
-if [[ "${TRAVIS_RUST_ARCHITECTURE}" == "i386" ]]; then
+if [ "${TRAVIS_RUST_ARCHITECTURE}" = "i386" ]; then
   RUST_TARGET="i686-unknown-linux-gnu"
 fi
 
-if [[ "${RUST_TARGET}" == "i686-unknown-linux-gnu" ]]; then
+if [ "${RUST_TARGET}" = "i686-unknown-linux-gnu" ]; then
   apt-get update
   apt-get install -y gcc-multilib
 fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -2,14 +2,21 @@
 
 set -ex
 
-if [[ "$TRAVIS_RUST_ARCHITECTURE" == "i386" ]]; then
-  apt-get update
-  apt-get install -y gcc-multilib
-  rustup target add i686-unknown-linux-gnu
+RUST_TARGET="x86_64-unknown-linux-gnu"
+
+if [[ "${TRAVIS_RUST_ARCHITECTURE}" == "i386" ]]; then
+  RUST_TARGET="i686-unknown-linux-gnu"
 fi
 
-cargo build --verbose
-cargo doc --verbose
+if [[ "${RUST_TARGET}" == "i686-unknown-linux-gnu" ]]; then
+  apt-get update
+  apt-get install -y gcc-multilib
+fi
+
+rustup target add ${RUST_TARGET}
+
+cargo build --verbose --target "${RUST_TARGET}"
+cargo doc --verbose --target "${RUST_TARGET}"
 
 # If we're testing on an older version of Rust, then only check that we
 # can build the crate. This is because the dev dependencies might be updated
@@ -20,7 +27,7 @@ if [ "$TRAVIS_RUST_VERSION" = "1.21.0" ]; then
   exit
 fi
 
-cargo test --verbose
+cargo test --verbose --target "${RUST_TARGET}"
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-  cargo bench --verbose --no-run
+  cargo bench --verbose --no-run --target "${RUST_TARGET}"
 fi


### PR DESCRIPTION
```
± docker run -it --rm -v $(pwd):/usr/src/app -w /usr/src/app rust:1.31 ./ci/script.sh
+ RUST_TARGET=x86_64-unknown-linux-gnu
+ [[  == i386 ]]
./ci/script.sh: 7: ./ci/script.sh: [[: not found
+ [[ x86_64-unknown-linux-gnu == i686-unknown-linux-gnu ]]
./ci/script.sh: 11: ./ci/script.sh: [[: not found
+ rustup target add x86_64-unknown-linux-gnu
component 'rust-std' for target 'x86_64-unknown-linux-gnu' was automatically added because it is required for toolchain '1.31.1-x86_64-unknown-linux-gnu'
+ cargo build --verbose --target x86_64-unknown-linux-gnu
    Updating crates.io index
  Downloaded lazy_static v1.4.0
  Downloaded byteorder v1.3.2
   Compiling byteorder v1.3.2
   Compiling lazy_static v1.4.0
     Running `rustc --crate-name build_script_build /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/byteorder-1.3.2/build.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=421f3a08dcdcb762 -C extra-filename=-421f3a08dcdcb762 --out-dir /usr/src/app/target/debug/build/byteorder-421f3a08dcdcb762 -L dependency=/usr/src/app/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name lazy_static /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/lazy_static-1.4.0/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=26fe57f192227249 -C extra-filename=-26fe57f192227249 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --cap-lints allow`
     Running `/usr/src/app/target/debug/build/byteorder-421f3a08dcdcb762/build-script-build`
     Running `rustc --crate-name byteorder /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/byteorder-1.3.2/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=f37776651b388edb -C extra-filename=-f37776651b388edb --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --cap-lints allow --cfg byteorder_i128`
   Compiling snap v0.2.5 (/usr/src/app)
     Running `rustc --crate-name snap src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=3161f10c5c0ba187 -C extra-filename=-3161f10c5c0ba187 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -C incremental=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/incremental -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern byteorder=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-f37776651b388edb.rlib --extern lazy_static=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblazy_static-26fe57f192227249.rlib`
    Finished dev [unoptimized + debuginfo] target(s) in 17.52s
+ cargo doc --verbose --target x86_64-unknown-linux-gnu
    Checking lazy_static v1.4.0
 Documenting lazy_static v1.4.0
     Running `rustc --crate-name lazy_static /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/lazy_static-1.4.0/src/lib.rs --color always --crate-type lib --emit=dep-info,metadata -C debuginfo=2 -C metadata=1a8aac932e8f651f -C extra-filename=-1a8aac932e8f651f --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --cap-lints allow`
     Running `rustdoc --crate-name lazy_static /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/lazy_static-1.4.0/src/lib.rs --cap-lints allow --color always --target x86_64-unknown-linux-gnu -o /usr/src/app/target/x86_64-unknown-linux-gnu/doc -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps`
 Documenting byteorder v1.3.2
     Running `rustdoc --crate-name byteorder /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/byteorder-1.3.2/src/lib.rs --cap-lints allow --color always --target x86_64-unknown-linux-gnu -o /usr/src/app/target/x86_64-unknown-linux-gnu/doc --cfg 'feature="default"' --cfg 'feature="std"' -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --cfg byteorder_i128`
    Checking byteorder v1.3.2
     Running `rustc --crate-name byteorder /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/byteorder-1.3.2/src/lib.rs --color always --crate-type lib --emit=dep-info,metadata -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=57fcbf683d391859 -C extra-filename=-57fcbf683d391859 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --cap-lints allow --cfg byteorder_i128`
 Documenting snap v0.2.5 (/usr/src/app)
     Running `rustdoc --crate-name snap src/lib.rs --color always --target x86_64-unknown-linux-gnu -o /usr/src/app/target/x86_64-unknown-linux-gnu/doc -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern byteorder=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-57fcbf683d391859.rmeta --extern lazy_static=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblazy_static-1a8aac932e8f651f.rmeta`
    Finished dev [unoptimized + debuginfo] target(s) in 6.52s
+ [  = 1.21.0 ]
+ cargo test --verbose --target x86_64-unknown-linux-gnu
  Downloaded quickcheck v0.7.2
  Downloaded rand v0.5.6
  Downloaded libc v0.2.65
  Downloaded rand_core v0.2.2
  Downloaded rand_core v0.3.1
  Downloaded rand_core v0.4.2
   Compiling libc v0.2.65
   Compiling rand_core v0.4.2
     Running `rustc --crate-name build_script_build /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.65/build.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=f4849864bb57356a -C extra-filename=-f4849864bb57356a --out-dir /usr/src/app/target/debug/build/libc-f4849864bb57356a -L dependency=/usr/src/app/target/debug/deps --cap-lints allow`
     Running `rustc --crate-name rand_core /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/rand_core-0.4.2/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 --cfg 'feature="alloc"' --cfg 'feature="std"' -C metadata=7cd087629f512acf -C extra-filename=-7cd087629f512acf --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --cap-lints allow`
       Fresh lazy_static v1.4.0
   Compiling rand_core v0.3.1
     Running `rustc --crate-name rand_core /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/rand_core-0.3.1/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 --cfg 'feature="alloc"' --cfg 'feature="rand_core"' --cfg 'feature="std"' -C metadata=ee5ece9cee04074a -C extra-filename=-ee5ece9cee04074a --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern rand_core=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand_core-7cd087629f512acf.rlib --cap-lints allow`
   Compiling rand_core v0.2.2
     Running `rustc --crate-name rand_core /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/rand_core-0.2.2/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=68be48a70a42c122 -C extra-filename=-68be48a70a42c122 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern rand_core=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand_core-ee5ece9cee04074a.rlib --cap-lints allow`
       Fresh byteorder v1.3.2
     Running `/usr/src/app/target/debug/build/libc-f4849864bb57356a/build-script-build`
     Running `rustc --crate-name libc /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.65/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="std"' -C metadata=f801d47696d3a5b6 -C extra-filename=-f801d47696d3a5b6 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --cap-lints allow --cfg freebsd11 --cfg libc_priv_mod_use --cfg libc_union --cfg libc_const_size_of --cfg libc_align --cfg libc_core_cvoid`
   Compiling rand v0.5.6
     Running `rustc --crate-name rand /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.5.6/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 --cfg 'feature="alloc"' --cfg 'feature="cloudabi"' --cfg 'feature="default"' --cfg 'feature="fuchsia-cprng"' --cfg 'feature="libc"' --cfg 'feature="rand_core"' --cfg 'feature="std"' --cfg 'feature="winapi"' -C metadata=daff5f58a5aec231 -C extra-filename=-daff5f58a5aec231 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern libc=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblibc-f801d47696d3a5b6.rlib --extern rand_core=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand_core-ee5ece9cee04074a.rlib --cap-lints allow`
   Compiling quickcheck v0.7.2
     Running `rustc --crate-name quickcheck /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/quickcheck-0.7.2/src/lib.rs --color always --crate-type lib --emit=dep-info,link -C debuginfo=2 -C metadata=192cfbd38180596f -C extra-filename=-192cfbd38180596f --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern rand=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand-daff5f58a5aec231.rlib --extern rand_core=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand_core-68be48a70a42c122.rlib --cap-lints allow`
   Compiling snap v0.2.5 (/usr/src/app)
     Running `rustc --crate-name snap src/lib.rs --color always --emit=dep-info,link -C opt-level=3 -C debuginfo=2 -C debug-assertions=on --test -C metadata=97f96c0ced973b8b -C extra-filename=-97f96c0ced973b8b --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps --target x86_64-unknown-linux-gnu -C incremental=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/incremental -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern byteorder=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-f37776651b388edb.rlib --extern lazy_static=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblazy_static-26fe57f192227249.rlib --extern quickcheck=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libquickcheck-192cfbd38180596f.rlib --extern rand=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand-daff5f58a5aec231.rlib`
     Running `rustc --crate-name decompress examples/decompress.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=bd8ff847e8ef27b6 -C extra-filename=-bd8ff847e8ef27b6 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/examples --target x86_64-unknown-linux-gnu -C incremental=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/incremental -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern byteorder=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-f37776651b388edb.rlib --extern lazy_static=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblazy_static-26fe57f192227249.rlib --extern quickcheck=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libquickcheck-192cfbd38180596f.rlib --extern rand=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand-daff5f58a5aec231.rlib --extern snap=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libsnap-3161f10c5c0ba187.rlib`
     Running `rustc --crate-name compress examples/compress.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=8fd3def5b49d92a1 -C extra-filename=-8fd3def5b49d92a1 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/examples --target x86_64-unknown-linux-gnu -C incremental=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/incremental -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern byteorder=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-f37776651b388edb.rlib --extern lazy_static=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblazy_static-26fe57f192227249.rlib --extern quickcheck=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libquickcheck-192cfbd38180596f.rlib --extern rand=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand-daff5f58a5aec231.rlib --extern snap=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libsnap-3161f10c5c0ba187.rlib`
     Running `rustc --crate-name compress_escaped examples/compress-escaped.rs --color always --crate-type bin --emit=dep-info,link -C debuginfo=2 -C metadata=a7b5bd5c9cff5983 -C extra-filename=-a7b5bd5c9cff5983 --out-dir /usr/src/app/target/x86_64-unknown-linux-gnu/debug/examples --target x86_64-unknown-linux-gnu -C incremental=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/incremental -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern byteorder=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-f37776651b388edb.rlib --extern lazy_static=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblazy_static-26fe57f192227249.rlib --extern quickcheck=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libquickcheck-192cfbd38180596f.rlib --extern rand=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand-daff5f58a5aec231.rlib --extern snap=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libsnap-3161f10c5c0ba187.rlib`
    Finished dev [unoptimized + debuginfo] target(s) in 33.09s
     Running `/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/snap-97f96c0ced973b8b`

running 62 tests
test tests::data_gaviota::roundtrip_raw ... ok
test tests::data_golden::roundtrip_frame ... ok
test tests::data_golden::roundtrip_raw ... ok
test tests::data_gaviota::roundtrip_frame ... ok
test tests::data_golden_rev ... ok
test tests::data_html4::roundtrip_raw ... ok
test tests::data_html4::roundtrip_frame ... ok
test tests::data_html::roundtrip_frame ... ok
test tests::data_html::roundtrip_raw ... ok
test tests::data_jpg::roundtrip_raw ... ok
test tests::data_jpg::roundtrip_frame ... ok
test tests::data_pb::roundtrip_frame ... ok
test tests::data_pb::roundtrip_raw ... ok
test tests::data_pdf::roundtrip_frame ... ok
test tests::data_pdf::roundtrip_raw ... ok
test tests::data_txt1::roundtrip_raw ... ok
test tests::data_txt1::roundtrip_frame ... ok
test tests::data_txt2::roundtrip_frame ... ok
test tests::data_txt2::roundtrip_raw ... ok
test tests::data_txt3::roundtrip_frame ... ok
test tests::data_txt3::roundtrip_raw ... ok
test tests::data_txt4::roundtrip_frame ... ok
test tests::data_txt4::roundtrip_raw ... ok
test tests::data_urls::roundtrip_frame ... ok
test tests::decompress_copy_close_to_end_1 ... ok
test tests::data_urls::roundtrip_raw ... ok
test tests::decompress_copy_close_to_end_2 ... ok
test tests::empty::roundtrip_frame ... ok
test tests::empty::roundtrip_raw ... ok
test tests::err_copy1 ... ok
test tests::err_copy2a ... ok
test tests::err_copy3a ... ok
test tests::err_copy2b ... ok
test tests::err_copy3c ... ok
test tests::err_copy3b ... ok
test tests::err_copy3d ... ok
test tests::err_copy_len_big ... ok
test tests::err_copy_offset_big ... ok
test tests::err_copy_offset_zero ... ok
test tests::err_empty ... ok
test tests::err_lit ... ok
test tests::err_header_mismatch ... ok
test tests::err_lit_big2a ... ok
test tests::err_lit_big1 ... ok
test tests::err_varint1 ... ok
test tests::err_lit_big2b ... ok
test tests::err_varint3 ... ok
test tests::err_varint2 ... ok
test tests::one_zero::roundtrip_raw ... ok
test tests::one_zero::roundtrip_frame ... ok
test tests::qc_roundtrip ... ok
test tests::random1::roundtrip_frame ... ok
test tests::random1::roundtrip_raw ... ok
test tests::random2::roundtrip_frame ... ok
test tests::random2::roundtrip_raw ... ok
test tests::random3::roundtrip_frame ... ok
test tests::random3::roundtrip_raw ... ok
test tests::random4::roundtrip_frame ... ok
test tests::random4::roundtrip_raw ... ok
test tests::small_copy ... ok
test tests::small_regular ... ok
test tests::qc_roundtrip_stream ... ok

test result: ok. 62 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests snap
     Running `rustdoc --test /usr/src/app/src/lib.rs --crate-name snap -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern byteorder=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-f37776651b388edb.rlib --extern lazy_static=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblazy_static-26fe57f192227249.rlib --extern quickcheck=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libquickcheck-192cfbd38180596f.rlib --extern rand=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand-daff5f58a5aec231.rlib --extern snap=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libsnap-3161f10c5c0ba187.rlib`

running 3 tests
test src/lib.rs -  (line 15) ... ignored
test src/lib.rs -  (line 47) ... ignored
test src/lib.rs -  (line 68) ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out

+ [  = nightly ]
```

```
± docker run -it --rm -e TRAVIS_RUST_ARCHITECTURE=i386 -v $(pwd):/usr/src/app -w /usr/src/app rust:1.31 ./ci/script.sh
+ RUST_TARGET=x86_64-unknown-linux-gnu
+ [[ i386 == i386 ]]
./ci/script.sh: 7: ./ci/script.sh: [[: not found
+ [[ x86_64-unknown-linux-gnu == i686-unknown-linux-gnu ]]
./ci/script.sh: 11: ./ci/script.sh: [[: not found
+ rustup target add x86_64-unknown-linux-gnu
component 'rust-std' for target 'x86_64-unknown-linux-gnu' was automatically added because it is required for toolchain '1.31.1-x86_64-unknown-linux-gnu'
+ cargo build --verbose --target x86_64-unknown-linux-gnu
    Updating crates.io index
  Downloaded lazy_static v1.4.0
  Downloaded byteorder v1.3.2
       Fresh lazy_static v1.4.0
       Fresh byteorder v1.3.2
       Fresh snap v0.2.5 (/usr/src/app)
    Finished dev [unoptimized + debuginfo] target(s) in 5.54s
+ cargo doc --verbose --target x86_64-unknown-linux-gnu
       Fresh lazy_static v1.4.0
       Fresh byteorder v1.3.2
       Fresh snap v0.2.5 (/usr/src/app)
    Finished dev [unoptimized + debuginfo] target(s) in 0.55s
+ [  = 1.21.0 ]
+ cargo test --verbose --target x86_64-unknown-linux-gnu
  Downloaded rand v0.5.6
  Downloaded libc v0.2.65
  Downloaded rand_core v0.3.1
  Downloaded rand_core v0.4.2
  Downloaded quickcheck v0.7.2
  Downloaded rand_core v0.2.2
       Fresh rand_core v0.4.2
       Fresh lazy_static v1.4.0
       Fresh rand_core v0.3.1
       Fresh libc v0.2.65
       Fresh rand_core v0.2.2
       Fresh byteorder v1.3.2
       Fresh rand v0.5.6
       Fresh quickcheck v0.7.2
       Fresh snap v0.2.5 (/usr/src/app)
    Finished dev [unoptimized + debuginfo] target(s) in 2.69s
     Running `/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/snap-97f96c0ced973b8b`

running 62 tests
test tests::data_gaviota::roundtrip_raw ... ok
test tests::data_gaviota::roundtrip_frame ... ok
test tests::data_golden::roundtrip_raw ... ok
test tests::data_golden::roundtrip_frame ... ok
test tests::data_golden_rev ... ok
test tests::data_html4::roundtrip_raw ... ok
test tests::data_html4::roundtrip_frame ... ok
test tests::data_html::roundtrip_raw ... ok
test tests::data_html::roundtrip_frame ... ok
test tests::data_jpg::roundtrip_raw ... ok
test tests::data_jpg::roundtrip_frame ... ok
test tests::data_pb::roundtrip_frame ... ok
test tests::data_pb::roundtrip_raw ... ok
test tests::data_pdf::roundtrip_raw ... ok
test tests::data_pdf::roundtrip_frame ... ok
test tests::data_txt1::roundtrip_raw ... ok
test tests::data_txt1::roundtrip_frame ... ok
test tests::data_txt2::roundtrip_frame ... ok
test tests::data_txt2::roundtrip_raw ... ok
test tests::data_txt3::roundtrip_frame ... ok
test tests::data_txt3::roundtrip_raw ... ok
test tests::data_txt4::roundtrip_frame ... ok
test tests::data_txt4::roundtrip_raw ... ok
test tests::data_urls::roundtrip_frame ... ok
test tests::decompress_copy_close_to_end_1 ... ok
test tests::decompress_copy_close_to_end_2 ... ok
test tests::empty::roundtrip_frame ... ok
test tests::empty::roundtrip_raw ... ok
test tests::err_copy1 ... ok
test tests::err_copy2a ... ok
test tests::err_copy2b ... ok
test tests::err_copy3a ... ok
test tests::err_copy3b ... ok
test tests::err_copy3c ... ok
test tests::err_copy3d ... ok
test tests::err_copy_len_big ... ok
test tests::err_copy_offset_big ... ok
test tests::err_copy_offset_zero ... ok
test tests::err_empty ... ok
test tests::err_header_mismatch ... ok
test tests::err_lit ... ok
test tests::err_lit_big1 ... ok
test tests::err_lit_big2a ... ok
test tests::err_lit_big2b ... ok
test tests::err_varint1 ... ok
test tests::err_varint2 ... ok
test tests::err_varint3 ... ok
test tests::one_zero::roundtrip_frame ... ok
test tests::one_zero::roundtrip_raw ... ok
test tests::data_urls::roundtrip_raw ... ok
test tests::qc_roundtrip ... ok
test tests::random1::roundtrip_frame ... ok
test tests::random1::roundtrip_raw ... ok
test tests::random2::roundtrip_frame ... ok
test tests::random2::roundtrip_raw ... ok
test tests::random3::roundtrip_frame ... ok
test tests::random3::roundtrip_raw ... ok
test tests::random4::roundtrip_frame ... ok
test tests::random4::roundtrip_raw ... ok
test tests::small_copy ... ok
test tests::small_regular ... ok
test tests::qc_roundtrip_stream ... ok

test result: ok. 62 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests snap
     Running `rustdoc --test /usr/src/app/src/lib.rs --crate-name snap -L dependency=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps -L dependency=/usr/src/app/target/debug/deps --extern byteorder=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libbyteorder-f37776651b388edb.rlib --extern lazy_static=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/liblazy_static-26fe57f192227249.rlib --extern quickcheck=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libquickcheck-192cfbd38180596f.rlib --extern rand=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/librand-daff5f58a5aec231.rlib --extern snap=/usr/src/app/target/x86_64-unknown-linux-gnu/debug/deps/libsnap-3161f10c5c0ba187.rlib`

running 3 tests
test src/lib.rs -  (line 15) ... ignored
test src/lib.rs -  (line 47) ... ignored
test src/lib.rs -  (line 68) ... ignored

test result: ok. 0 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out

+ [  = nightly ]
```